### PR TITLE
Add find text

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,7 +8,7 @@ import { last, flatten } from "./utils";
 export function actionCommand(f: (stack: Stack, main: Extension) => Thenable<void>): Command {
   return async (stack: Stack, main: Extension) => {
     await f(stack, main);
-    return [stack, undefined];
+    return { stack };
   };
 }
 
@@ -18,7 +18,7 @@ function insert(before: boolean): Command {
     const editor = window.activeTextEditor!;
     editor.selections = editor.selections.map((s) => new Selection(s[prop], s[prop]));
     main.enterInsertMode();
-    return [undefined, undefined];
+    return { stack: undefined };
   };
 }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -100,6 +100,7 @@ addBinding("w", textObjects.word);
 addBinding("\"", textObjects.quotes);
 addBinding("`", textObjects.tick);
 addBinding("~", textObjects.tripleTick);
+addBinding("d", textObjects.findText);
 
 // right hand homerow
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,17 +1,21 @@
-import { Extension, KeyHandler } from "./extension";
+import { Extension } from "./extension";
 import { Stack, Stackable, cons } from "./stack";
-export type Command = (stack: Stack, main: Extension) => Promise<[Stack, KeyHandler | undefined]>;
+
+export type CommandResult = Promise<{ stack: Stack, handler?: KeyCommand }>;
+
+export type Command = (stack: Stack, main: Extension) => CommandResult;
+export type KeyCommand = (stack: Stack, main: Extension, key: string) => CommandResult;
 
 export function pushToStack(element: Stackable): Command {
-  return async (stack) => [cons(element, stack), undefined];
+  return async (stack) => ({ stack: cons(element, stack) });
 }
 
 export function composeCommand(...commands: Command[]): Command {
   return async (stack: Stack, main: Extension) => {
     let handler;
     for (const command of commands) {
-      [stack, handler] = await command(stack, main);
+      ({ stack, handler } = await command(stack, main));
     }
-    return [stack, handler];
+    return { stack, handler };
   };
 }

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -1,5 +1,3 @@
-import { HandlerResult } from "./extension";
-
 export interface Stackable {
   toString: () => string;
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -134,7 +134,7 @@ function doDescriptions(descriptions: Describe[]): void {
       if (description.cases !== undefined) {
         doDescriptions(description.cases);
       }
-    })
+    });
   }
 }
 

--- a/test/extension.yaml
+++ b/test/extension.yaml
@@ -522,3 +522,17 @@
         start: "```|```"
         input: e~
         selection is: "``````"
+
+- describe: findText
+  scenarios:
+  - it: selects the next occurrence
+    start: |
+      |here is a bunch of words
+    input: "dbunch\n"
+    selection is: bunch
+  - it: selects the previous occurrence
+    start: |
+      there is a lot
+      of text on these l[in]es
+    input: "pdlot\n"
+    selection is: "lot"


### PR DESCRIPTION
* Add `find-text`
* Less logic in `handleInput`. Custom key handlers and bindings are handled identically.
* Key handlers can be asynchronous, modify the stack, etc.
* Commands return an object instead of a pair.